### PR TITLE
some svg's require to use fill for color change

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,9 +65,13 @@ import { Icon } from 'astro-icon';
 <style lang="css">
     [astro-icon] {
         color: blue;
+        /* OR */
+        fill: blue;
     }
     [astro-icon="annotation"] {
         color: red;
+        /* OR */
+        fill: red;
     }
 </style>
 


### PR DESCRIPTION
just noticed that my icomoon svg's aren't showing up as intended, using fill instead of color worked. 