### PR TITLE
Referenced the official icon sets reference

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,7 +28,7 @@ export default {
 
 `astro-icon` automatically includes all of the most common icon packs, powered by [Iconify](https://iconify.design/)!
 
-To browse supported icons, we recommend [Icônes](https://icones.js.org/).
+To browse supported icons, check the official [Icon Sets reference](https://icon-sets.iconify.design/) or visit [Icônes](https://icones.js.org/).
 
 ### Usage
 


### PR DESCRIPTION
The `README.md` file didn't contain a reference to the official icon sets reference of *Iconify*. This PR includes a reference to https://icon-sets.iconify.design/.