### PR TITLE
fix: show icon with gradients in Chrome

### DIFF
--- a/.changeset/eleven-rocks-complain.md
+++ b/.changeset/eleven-rocks-complain.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fix Chrome not rendering icons using SVG gradients

--- a/packages/core/lib/Spritesheet.astro
+++ b/packages/core/lib/Spritesheet.astro
@@ -24,6 +24,6 @@ ${e}`);
 }));
 ---
 
-<svg style={`display: none; ${style ?? ''}`.trim()} {...{ 'aria-hidden': true, ...props }} astro-icon-spritesheet>
+<svg style={`position: absolute; width: 0; height: 0; overflow: hidden; ${style ?? ''}`.trim()} {...{ 'aria-hidden': true, ...props }} astro-icon-spritesheet>
     {icons.map(icon => (<symbol {...icon.props} id={`${SPRITESHEET_NAMESPACE}:${icon.name}`} set:html={icon.innerHTML} />))}
 </svg>


### PR DESCRIPTION
I noticed that some icons (like `logos:vitejs`) are not showing in Chrome, but they work fine in Firefox.

After some investigation, it seems that using `display: none` on the spritesheet's SVG causes gradients to don't work in Chrome. Resources:

- this old CSS-Tricks topic: https://css-tricks.com/forums/topic/gradients-and-hiding-symbol-defining-svg-blocks-in-html/
- this fairly new issue on SO: https://stackoverflow.com/questions/66199983/why-is-my-svgs-radialgradient-not-showing-in-chrome-based-browsers-but-does-in

I also created a [demo in CodePen to reproduce the issue](https://codepen.io/marco_solazzi/pen/abGKYqe) (screenshot below):

<img width="483" alt="image" src="https://user-images.githubusercontent.com/104721/193763249-b5c71c37-824c-4a46-8a33-cfb4ffb46b37.png">

This PR uses another technique to hide the spritesheet that should make everything work in Chrome.

For reference, here are my system's details:

```

  System:
    OS: macOS 12.5.1
  Binaries:
    Node: 16.17.0 
    Yarn: 1.22.4 
    npm: 8.15.0 
  Browsers:
    Chrome: 105.0.5195.125
    Firefox: 105.0.1
    Safari: 15.6.1
  npmPackages:
    astro-icon: 0.7.3 => 0.7.3
```
