### PR TITLE
Fix: add typing for SSRResult with extended astro-icon properties

### DIFF
--- a/.changeset/hungry-buttons-change.md
+++ b/.changeset/hungry-buttons-change.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Add strict typing for SSRResult with extended astro-icon properties

--- a/packages/core/lib/Sprite.astro
+++ b/packages/core/lib/Sprite.astro
@@ -10,7 +10,6 @@ if (pack) {
     name = `${pack}:${name}`;
 }
 const href = `#${SPRITESHEET_NAMESPACE}:${name}`;
-// @ts-ignore
 trackSprite($$result, name);
 ---
 

--- a/packages/core/lib/Spritesheet.astro
+++ b/packages/core/lib/Spritesheet.astro
@@ -9,7 +9,6 @@ export interface Props {
 }
 
 const { optimize = true, style, ...props } = Astro.props;
-// @ts-ignore
 const names = await getUsedSprites($$result);
 const icons = await Promise.all(names.map(name => {
     return load(name, {}, optimize)

--- a/packages/core/lib/context.ts
+++ b/packages/core/lib/context.ts
@@ -1,6 +1,17 @@
+import type { SSRResult } from 'astro/dist/types/@types/astro'
 const AstroIcon = Symbol("AstroIcon");
 
-export function trackSprite(result: any, name: string) {
+interface AstroIconSSRResult extends SSRResult {
+  [AstroIcon]: {
+    sprites: Set<string>
+  },
+}
+
+declare global {
+  var $$result: AstroIconSSRResult
+}
+
+export function trackSprite(result: AstroIconSSRResult, name: string) {
   if (typeof result[AstroIcon] !== "undefined") {
     result[AstroIcon]["sprites"].add(name);
   } else {
@@ -11,7 +22,7 @@ export function trackSprite(result: any, name: string) {
 }
 
 const warned = new Set();
-export async function getUsedSprites(result: any) {
+export async function getUsedSprites(result: AstroIconSSRResult) {
   if (typeof result[AstroIcon] !== "undefined") {
     return Array.from(result[AstroIcon]["sprites"]);
   }


### PR DESCRIPTION
Extended the `SSRResult` from `astro` to include the `AstroIcon` symbol property on the `SSRResult`. This allowed me to remove some `any`s and `@ts-ignore`s.