### PR TITLE
Chore: use `node:` prefix on node dependencies

### DIFF
--- a/.changeset/quiet-insects-cover.md
+++ b/.changeset/quiet-insects-cover.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Use `node:` prefix on standard node dependencies

--- a/packages/core/lib/createIconPack.ts
+++ b/packages/core/lib/createIconPack.ts
@@ -1,5 +1,5 @@
-import { statSync, promises as fs } from "fs";
-import { fileURLToPath, pathToFileURL } from "url";
+import { statSync, promises as fs } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import resolvePackage from "resolve-pkg";
 
 export interface CreateIconPackOptions {


### PR DESCRIPTION
Updates node dependencies to use the `node:` prefix. 

**Benefits:**
- More explicit protocol makes it more readable and also makes it clear that a built-in module is being imported. Since there are a lot of built-in ones, this extra information is useful for beginners or for someone who might not know about one of them.
- It reduces the risk of a module present in node_modules overriding the newer imports.

Supported in Node.js starting:
- v16.0.0, v14.18.0 (ESM import and CommonJS require())
- v14.13.1, v12.20.0 (only ESM import)

Supported in TypeScript by the latest versions of `@types/node`.