### PR TITLE
Update Sprite context to use `Astro.request`

### DIFF
--- a/.changeset/fuzzy-insects-flash.md
+++ b/.changeset/fuzzy-insects-flash.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Update Sprite context to track usages using `Astro.request`

--- a/packages/core/lib/Sprite.astro
+++ b/packages/core/lib/Sprite.astro
@@ -10,8 +10,7 @@ if (pack) {
     name = `${pack}:${name}`;
 }
 const href = `#${SPRITESHEET_NAMESPACE}:${name}`;
-// @ts-ignore
-trackSprite($$result, name);
+trackSprite(Astro.request, name);
 ---
 
 <svg {...props} class={className} astro-icon={name}>

--- a/packages/core/lib/Spritesheet.astro
+++ b/packages/core/lib/Spritesheet.astro
@@ -9,8 +9,7 @@ export interface Props {
 }
 
 const { optimize = true, style, ...props } = Astro.props;
-// @ts-ignore
-const names = await getUsedSprites($$result);
+const names: string[] = await getUsedSprites(Astro.request);
 const icons = await Promise.all(names.map(name => {
     return load(name, {}, optimize)
         .then(res => ({ ...res, name }))


### PR DESCRIPTION
This PR updates the `Sprite` context to utilize `Astro.request` instead of hacking the Astro `SSRResult` for tracking the `Sprite` usages. This also removes a few `@ts-ignore`s which are always nice to remove.

This replaces #58 with a correct fix.