### PR TITLE
Adds a customFill prop to allow filling the icons with things like gradients

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
-# Astro Icon
-
+# Fork of Astro Icon
+THIS IS A FORK OF THE ORIGINAL [ASTRO ICON COMPONENT](https://github.com/natemoo-re/astro-icon)
 A straight-forward `Icon` component for [Astro](https://astro.build).
 
 ## Install `astro-icon`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -155,4 +155,26 @@ The `optimize` prop is a boolean. Defaults to `true`. In the future it will cont
 
 Both components also accepts any global HTML attributes and `aria` attributes. They will be forwarded to the rendered `<svg>` element.
 
+The `customFill` prop takes a string and is not required. If you want to pass a custom `fill` color to the `<path>` element in the `<svg>`, you can use the `customFill` prop. This can be useful for icons that have multiple colors or gradients.
+```astro
+---
+import { Icon } from "astro-icon";
+---
+<!-- You can pass in anything that the normal fill attribute would accept -->
+<Icon customFill="#1DA1F2" class="bigIcon" pack="mdi" name="twitter" />
+<!-- To do a gradient, you have to include another svg element with the gradient and reference that is the Icons customFill -->
+<Icon customFill="url('#rg')" class="bigIcon" pack="mdi" name="instagram" />
+<!-- The gradient svg for the example -->
+<svg width="0" height="0">
+	<radialGradient id="rg" r="150%" cx="30%" cy="107%">
+		<stop stop-color="#fdf497" offset="0"></stop>
+		<stop stop-color="#fdf497" offset="0.05"></stop>
+		<stop stop-color="#fd5949" offset="0.45"></stop>
+		<stop stop-color="#d6249f" offset="0.6"></stop>
+		<stop stop-color="#285AEB" offset="0.9"></stop>
+	</radialGradient>
+</svg>
+
+```
+
 See the [`Props.ts`](./packages/core/lib/Props.ts) file for more details.

--- a/packages/core/lib/Icon.astro
+++ b/packages/core/lib/Icon.astro
@@ -2,7 +2,7 @@
 import load, { fallback, normalizeProps } from './utils.ts';
 export { Props } from './Props.ts';
 
-let { name, pack, title, optimize = true, class: className, ...inputProps } = Astro.props;
+let { name, pack, title, optimize = true, customFill, class: className, ...inputProps } = Astro.props;
 let props = {};
 if (pack) {
     name = `${pack}:${name}`;
@@ -22,6 +22,14 @@ ${e}`)
     props = { ...fallback.props, ...normalizeProps(inputProps) };
     title = `Failed to load "${name}"!`
     console.error(e);
+}
+
+// remove the text "currentColor" from innerHTML
+// replace "" with `${customFill}` in innerHTML if customFill is defined
+if (customFill != undefined) {
+    innerHTML = innerHTML.replace("currentColor", '');
+
+    innerHTML = innerHTML.replace('""', `"${customFill}"`);
 }
 ---
 


### PR DESCRIPTION
I was using this package and it was very helpful. However, I ran into an issue when trying to color the Instagram icon to match the actual logo. I found a way to apply a gradient to the logo via a prop and a second svg element with the gradient. It's probably not the most elegant solution but it could help other people so figured I'd make a request. I also updated the README.md to reflect the new prop and its usage. Any of this can be changed if you have a better solution.