### PR TITLE
fix: move no sprite log to debug level

### DIFF
--- a/.changeset/silent-waves-peel.md
+++ b/.changeset/silent-waves-peel.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+move no sprite log to debug level

--- a/packages/core/lib/context.ts
+++ b/packages/core/lib/context.ts
@@ -20,7 +20,9 @@ export async function getUsedSprites(request: AstroRequest): Promise<string[]> {
   }
   if (!warned.has(request)) {
     const { pathname } = new URL(request.url);
-    console.log(`[astro-icon] No sprites found while rendering "${pathname}"`);
+    console.debug(
+      `[astro-icon] No sprites found while rendering "${pathname}"`
+    );
     warned.add(request);
   }
   return [];


### PR DESCRIPTION
Moved message to debug level as in some scenarios when `Sprite.Provider` is used inside a common Astro `Layout` component, server is bloated with many false positive logs about the missing sprite.

- Fix https://github.com/natemoo-re/astro-icon/issues/71