### PR TITLE
fix: prevent missing local collection from failing build

### DIFF
--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -28,9 +28,13 @@ export async function createPlugin(
     },
     async load(id) {
       if (id === resolvedVirtualModuleId) {
-        // Create local collection
-        const local = await loadLocalCollection(iconDir);
-        collections["local"] = local;
+        try {
+          // Attempt to create local collection
+          const local = await loadLocalCollection(iconDir);
+          collections["local"] = local;
+        } catch (ex) {
+          console.warn('Unable to load local collection. Ensure you have your `iconDir` configured properly.')
+        }
         await generateIconTypeDefinitions(Object.values(collections), root);
 
         return `import.meta.glob('/src/icons/**/*.svg');

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -33,7 +33,9 @@ export async function createPlugin(
           const local = await loadLocalCollection(iconDir);
           collections["local"] = local;
         } catch (ex) {
-          console.warn('Unable to load local collection. Ensure you have your `iconDir` configured properly.')
+          console.warn(
+            "Unable to load local collection. Ensure you have your `iconDir` configured properly."
+          );
         }
         await generateIconTypeDefinitions(Object.values(collections), root);
 


### PR DESCRIPTION
The `importDirectory` function will throw if the passed `dir` is not present. This will catch any error from the local collection generation and warn about it. This should be the only thing that triggers this catch. 