### PR TITLE
move warning about local directory to on use

### DIFF
--- a/.changeset/fuzzy-beers-count.md
+++ b/.changeset/fuzzy-beers-count.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+move warning about local directory to on use

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -42,6 +42,16 @@ if (!iconName) {
   iconName = setName;
   setName = "local";
 
+  // Check if the local icon set exists
+  if (!icons[setName]) {
+    const err = new Error('Unable to load the "local" icon set!');
+    if (import.meta.env.DEV) {
+      err.hint =
+        'It looks like the "local" set was not loaded.\n\nDid you forget to create the icon directory or to update your config?';
+    }
+    throw err;
+  }
+
   // Check if the icon is missing from the local collection
   if (!(iconName in icons[setName].icons)) {
     const err = new Error(`Unable to locate "${name}" icon!`);

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -33,9 +33,7 @@ export async function createPlugin(
           const local = await loadLocalCollection(iconDir);
           collections["local"] = local;
         } catch (ex) {
-          console.warn(
-            "Unable to load local collection. Ensure you have your `iconDir` configured properly."
-          );
+          // Failed to load the local collection
         }
         await generateIconTypeDefinitions(Object.values(collections), root);
 


### PR DESCRIPTION
Moves the warning about a missing local directory/collection to only apply on usage of a local icon