### PR TITLE
fix: correctly pass SVGO Options

### DIFF
--- a/.changeset/violet-experts-travel.md
+++ b/.changeset/violet-experts-travel.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+fix: correctly pass SVGO Options

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -9,7 +9,7 @@ import loadLocalCollection from "./loaders/loadLocalCollection.js";
 import loadIconifyCollections from "./loaders/loadIconifyCollections.js";
 
 export async function createPlugin(
-  { include = {}, iconDir = "src/icons" }: IntegrationOptions,
+  { include = {}, iconDir = "src/icons", svgoOptions }: IntegrationOptions,
   { root }: Pick<AstroConfig, "root">
 ): Promise<Plugin> {
   const virtualModuleId = "virtual:astro-icon";
@@ -30,7 +30,7 @@ export async function createPlugin(
       if (id === resolvedVirtualModuleId) {
         try {
           // Attempt to create local collection
-          const local = await loadLocalCollection(iconDir);
+          const local = await loadLocalCollection(iconDir, svgoOptions);
           collections["local"] = local;
         } catch (ex) {
           // Failed to load the local collection


### PR DESCRIPTION
As pointed out in #100, it seems we had a bad merge conflict resolution. This properly passes the options through.