### PR TITLE
fix type import

### DIFF
--- a/.changeset/tough-wombats-hang.md
+++ b/.changeset/tough-wombats-hang.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+fix type import

--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -1,5 +1,5 @@
 import { SPRITESHEET_NAMESPACE } from "./constants";
-import { Props, Optimize } from "./Props";
+import { type Props, type Optimize } from "./Props";
 import getFromService from "./resolver";
 import { optimize as optimizeSVGNative } from "svgo";
 

--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -1,5 +1,5 @@
 import { SPRITESHEET_NAMESPACE } from "./constants";
-import { type Props, type Optimize } from "./Props";
+import type { Props, Optimize } from "./Props";
 import getFromService from "./resolver";
 import { optimize as optimizeSVGNative } from "svgo";
 


### PR DESCRIPTION
Build an astro v3.0 project with `astro-icon`, and get a warnning:

![image](https://github.com/natemoo-re/astro-icon/assets/25167721/a56f58ad-4133-41d8-8cb7-60d89b4c58ea)

Maybe it's because of the v3.0 change: https://docs.astro.build/en/guides/upgrade-to/v3/#changed-default-verbatimmodulesyntax-in-tsconfigjson-presets