### PR TITLE
Get rid of `astro-icon` attribute because of w3c validator error

### DIFF
--- a/packages/core/lib/Icon.astro
+++ b/packages/core/lib/Icon.astro
@@ -25,4 +25,4 @@ ${e}`)
 }
 ---
 
-<svg {...props} astro-icon={name} set:html={(title ? `<title>${title}</title>` : '') + innerHTML} />
+<svg {...props} set:html={(title ? `<title>${title}</title>` : '') + innerHTML} />


### PR DESCRIPTION
 Attribute `astro-icon` not allowed on element svg according [w3c validator](https://validator.w3.org/)

<img width="925" alt="Screenshot 2023-09-15 at 19 47 10" src="https://github.com/natemoo-re/astro-icon/assets/2094547/383a40a3-c002-4b82-b399-dca338bd0161">
