### PR TITLE
fix(createIconPack): handle unresolved modules

### DIFF
--- a/.changeset/great-carpets-hide.md
+++ b/.changeset/great-carpets-hide.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+fix(createIconPack): handle unresolved modules

--- a/.changeset/great-carpets-hide.md
+++ b/.changeset/great-carpets-hide.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-fix(createIconPack): handle unresolved modules
+Fixes an edge case with `createIconPack` when a module cannot be resolved

--- a/packages/core/lib/createIconPack.ts
+++ b/packages/core/lib/createIconPack.ts
@@ -15,7 +15,14 @@ export function createIconPack({
 }: CreateIconPackOptions) {
   if (pkg) {
     return async (name: string) => {
-      const baseUrl = new URL(pathToFileURL(resolvePackage(pkg)) + "/");
+      const pkgPath = resolvePackage(pkg);
+      if (!pkgPath) {
+        throw new Error(
+          `[astro-icon] Unable to resolve "${pkgPath}"! Is the package installed?"`
+        );
+      }
+
+      const baseUrl = new URL(pathToFileURL(pkgPath) + "/");
       const path = fileURLToPath(
         new URL(dir ? `${dir}/${name}.svg` : `${name}.svg`, baseUrl)
       );


### PR DESCRIPTION
When trying to build a site with a custom icon pack using the `astro/tsconfigs/strict` [TSConfig](https://docs.astro.build/en/guides/typescript/#setup), `tsc --noEmit` fails:

> Error: node_modules/.pnpm/astro-icon@0.8.1/node_modules/astro-icon/lib/createIconPack.ts(18,45): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
>   Type 'undefined' is not assignable to type 'string'.
>  ELIFECYCLE  Command failed with exit code 2.

It turns out that [`resolvePackage` may return `undefined`](https://github.com/sindresorhus/resolve-pkg/blob/72020a878937aafb9ec42eaa2692bf6101c69123/index.js#L19-L21), therefore this edge-case should be handled.