### PR TITLE
perf(createIconPack): improve local icon resolution

### DIFF
--- a/.changeset/young-chicken-hear.md
+++ b/.changeset/young-chicken-hear.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-perf(createIconPack): improve local icon resolution
+Improves the performance for `createIconPack`'s local icon resolution

--- a/.changeset/young-chicken-hear.md
+++ b/.changeset/young-chicken-hear.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+perf(createIconPack): improve local icon resolution

--- a/packages/core/lib/createIconPack.ts
+++ b/packages/core/lib/createIconPack.ts
@@ -1,4 +1,4 @@
-import { statSync, promises as fs } from "node:fs";
+import * as fs from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import resolvePackage from "resolve-pkg";
 
@@ -19,13 +19,14 @@ export function createIconPack({
       const path = fileURLToPath(
         new URL(dir ? `${dir}/${name}.svg` : `${name}.svg`, baseUrl)
       );
-      if (!exists(path)) {
+      try {
+        const svg = fs.readFileSync(path, "utf8");
+        return svg;
+      } catch {
         throw new Error(
           `[astro-icon] Unable to load "${path}"! Does the file exist?"`
         );
       }
-      const svg = await fs.readFile(path).then((res) => res.toString());
-      return svg;
     };
   }
 
@@ -48,10 +49,3 @@ export function createIconPack({
     };
   }
 }
-
-const exists = (path: string): boolean => {
-  try {
-    return statSync(path).isFile();
-  } catch (e) {}
-  return false;
-};

--- a/packages/core/lib/createIconPack.ts
+++ b/packages/core/lib/createIconPack.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import * as fs from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import resolvePackage from "resolve-pkg";
 
@@ -20,7 +20,7 @@ export function createIconPack({
         new URL(dir ? `${dir}/${name}.svg` : `${name}.svg`, baseUrl)
       );
       try {
-        const svg = fs.readFileSync(path, "utf8");
+        const svg = await fs.readFile(path, "utf8");
         return svg;
       } catch {
         throw new Error(


### PR DESCRIPTION
The existence of a file shouldn’t be checked in advance, as that doesn’t guarantee that the given file can actually be read. Therefore, our best bet is to just try reading directly from the file and then handle errors.