### PR TITLE
Replace `globEager` to fix Vite 5 incompatability

### DIFF
--- a/.changeset/great-cameras-drum.md
+++ b/.changeset/great-cameras-drum.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fixes incompatability with Vite 5 by removing a deprecated method

--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -189,7 +189,10 @@ ${contents}`
     filepath = `/src/icons/${name}.svg`;
 
     try {
-      const files = import.meta.glob("/src/icons/**/*.svg", { eager: true, as: "raw" });
+      const files = import.meta.glob("/src/icons/**/*.svg", {
+        eager: true,
+        as: "raw",
+      });
 
       if (!(filepath in files)) {
         throw new Error(`Could not find the file "${filepath}"`);

--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -145,8 +145,9 @@ export default async function load(
     filepath = `/src/icons/${pack}`;
     let get;
     try {
-      const files = import.meta.globEager(
-        "/src/icons/**/*.{js,ts,cjs,mjc,cts,mts}"
+      const files = import.meta.glob(
+        "/src/icons/**/*.{js,ts,cjs,mjc,cts,mts}",
+        { eager: true }
       );
       const keys = Object.fromEntries(
         Object.keys(files).map((key) => [key.replace(/\.[cm]?[jt]s$/, ""), key])
@@ -188,7 +189,7 @@ ${contents}`
     filepath = `/src/icons/${name}.svg`;
 
     try {
-      const files = import.meta.globEager("/src/icons/**/*.svg", { as: "raw" });
+      const files = import.meta.glob("/src/icons/**/*.svg", { eager: true, as: "raw" });
 
       if (!(filepath in files)) {
         throw new Error(`Could not find the file "${filepath}"`);


### PR DESCRIPTION
Hey folks! Sorry I've been away! Astro itself has been my main focus for a while and it's difficult to find time for other maintenance.

Got some reports of `astro-icon` breaking in Astro 4 and tracked it to an old API that was removed in Vite 5. This PR fixes that and will result in a patch release.

I will be opening an issue to share my thoughts on the future of `astro-icon` soon!