### PR TITLE
removed attribute 'astro-icon' from svg. reason: error on validator.w…

### DIFF
--- a/packages/core/lib/Icon.astro
+++ b/packages/core/lib/Icon.astro
@@ -25,4 +25,4 @@ ${e}`)
 }
 ---
 
-<svg {...props} astro-icon={name} set:html={(title ? `<title>${title}</title>` : '') + innerHTML} />
+<svg {...props} set:html={(title ? `<title>${title}</title>` : '') + innerHTML} />

--- a/packages/core/lib/Sprite.astro
+++ b/packages/core/lib/Sprite.astro
@@ -13,7 +13,7 @@ const href = `#${SPRITESHEET_NAMESPACE}:${name}`;
 trackSprite(Astro.request, name);
 ---
 
-<svg {...props} class={className} astro-icon={name}>
+<svg {...props} class={className}>
     {title ? (<title>{title}</title>) : ''}
     <use {...{ 'xlink:href': href, width: props.width, height: props.height, x, y }}  />
 </svg>


### PR DESCRIPTION
Removed attribute 'astro-icon' from svg. Reason: Error on validator.w3.org with error message "Attribute 'astro-icon' not allowed on element 'svg' at this point."
