### PR TITLE
Match v0 name behavior for local icons

### DIFF
--- a/.changeset/hungry-steaks-relax.md
+++ b/.changeset/hungry-steaks-relax.md
@@ -1,0 +1,21 @@
+---
+"astro-icon": patch
+---
+
+**BREAKING**: Requires subdirectory prefixes for local icons.
+
+This fixes a regression introduced in v1 and matches the previous v0 `name` behavior.
+
+As an example, the `src/icons/logos/astro.svg` file could previously be referenced by the name `astro`. It should correctly be referenced as `logos/astro`.
+
+**Before**
+
+```jsx
+<Icon name="astro" />
+```
+
+**After**
+
+```jsx
+<Icon name="logos/astro" />
+```

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -19,10 +19,10 @@ const icon = "adjustment";
     <Icon size={24} name="adjustment" />
     <Icon size={24} name={icon} />
     <Icon size={24} name="annotation" />
-    <Icon size={24} name="deno" />
-    <Icon name="deno" />
-    <Icon width={75} name="alpine" />
-    <Icon name="alpine-multi-color" />
+    <Icon size={24} name="logos/deno" />
+    <Icon name="logos/deno" />
+    <Icon width={75} name="logos/alpine" />
+    <Icon name="logos/alpine-multi-color" />
   </article>
 
   <article>

--- a/packages/core/src/loaders/loadLocalCollection.ts
+++ b/packages/core/src/loaders/loadLocalCollection.ts
@@ -17,7 +17,7 @@ export default async function createLocalCollection(
     prefix: "local",
     keepTitles: true,
     includeSubDirs: true,
-    keyword: (file) => file.subdir + file.file
+    keyword: (file) => file.subdir + file.file,
   });
 
   // Validate, clean up, fix palette and optimize

--- a/packages/core/src/loaders/loadLocalCollection.ts
+++ b/packages/core/src/loaders/loadLocalCollection.ts
@@ -16,6 +16,8 @@ export default async function createLocalCollection(
   const local = await importDirectory(dir, {
     prefix: "local",
     keepTitles: true,
+    includeSubDirs: true,
+    keyword: (file) => file.subdir + file.file
   });
 
   // Validate, clean up, fix palette and optimize


### PR DESCRIPTION
Fixes #178

**BREAKING**: Subdirectory prefixes are **required** for local icons.

This fixes a regression introduced in v1 and matches the previous v0 `name` behavior.

As an example, the `src/icons/logos/astro.svg` file could previously be referenced by the name `astro`. It should correctly be referenced by the name `logos/astro`.

**Before**

```jsx
<Icon name="astro" />
```

**After**

```jsx
<Icon name="logos/astro" />
```