### PR TITLE
Removes warning when no icon packs are found

### DIFF
--- a/.changeset/two-lizards-double.md
+++ b/.changeset/two-lizards-double.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Removes an unecessary warning when only using local icons

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -34,7 +34,6 @@ export function createPlugin(
       if (id === resolvedVirtualModuleId) {
         if (!collections) {
           collections = await loadIconifyCollections({ root, include });
-          logCollections(collections, ctx);
         }
         try {
           // Attempt to create local collection
@@ -43,6 +42,7 @@ export function createPlugin(
         } catch (ex) {
           // Failed to load the local collection
         }
+        logCollections(collections, { ...ctx, iconDir });
         await generateIconTypeDefinitions(Object.values(collections), root);
 
         return `export default ${JSON.stringify(
@@ -55,13 +55,16 @@ export function createPlugin(
 
 function logCollections(
   collections: AstroIconCollectionMap,
-  { logger }: PluginContext,
+  { logger, iconDir  }: PluginContext & { iconDir: string },
 ) {
   if (Object.keys(collections).length === 0) {
     logger.warn("No icons detected!");
     return;
   }
-  const names: string[] = Object.keys(collections);
+  const names: string[] = Object.keys(collections).filter(v => v !== 'local');
+  if (collections['local']) {
+    names.unshift(iconDir);
+  }
   logger.info(`Loaded icons from ${names.join(", ")}`);
 }
 

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -55,14 +55,14 @@ export function createPlugin(
 
 function logCollections(
   collections: AstroIconCollectionMap,
-  { logger, iconDir  }: PluginContext & { iconDir: string },
+  { logger, iconDir }: PluginContext & { iconDir: string },
 ) {
   if (Object.keys(collections).length === 0) {
     logger.warn("No icons detected!");
     return;
   }
-  const names: string[] = Object.keys(collections).filter(v => v !== 'local');
-  if (collections['local']) {
+  const names: string[] = Object.keys(collections).filter((v) => v !== "local");
+  if (collections["local"]) {
     names.unshift(iconDir);
   }
   logger.info(`Loaded icons from ${names.join(", ")}`);


### PR DESCRIPTION
Fixes #176

The warning for missing collections was accidentally logged before the local collection was loaded.

The log message has also been improved to include the directory of the local icon source first.