### PR TITLE
Warn and continue when local icon cannot be loaded

### DIFF
--- a/.changeset/heavy-insects-yawn.md
+++ b/.changeset/heavy-insects-yawn.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Improves handling of invalid local icons, which previously caused all local icons to silently fail.

--- a/packages/core/src/loaders/loadLocalCollection.ts
+++ b/packages/core/src/loaders/loadLocalCollection.ts
@@ -17,6 +17,7 @@ export default async function createLocalCollection(
     prefix: "local",
     keepTitles: true,
     includeSubDirs: true,
+    ignoreImportErrors: 'warn',
     keyword: (file) => file.subdir + file.file,
   });
 


### PR DESCRIPTION
Closes #183.

Previously, invalid local icons would cause the entire local icon set to silently fail.
By using `ignoreImportErrors: 'warn'`, invalid icons are now logged and ignored while valid icons are properly loaded.