### PR TITLE
fix: inherit viewbox width / height of none provided

### DIFF
--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -100,7 +100,7 @@ if (props.size) {
   props.height = props.size;
   delete props.size;
 }
-const renderData = iconToSVG(iconData);
+const renderData = iconToSVG(iconData, { width: "auto", height: "auto" });
 const normalizedProps = { ...renderData.attributes, ...props };
 const normalizedBody = renderData.body;
 ---


### PR DESCRIPTION
Currently if no width or height attributes provided to Icon component - it receives some weird rem units. This fix allows inheriting view box values if no width / height is provided.