### PR TITLE
docs(typo): Add missing word 'care'

### DIFF
--- a/packages/www/src/content/docs/guides/deployment.mdx
+++ b/packages/www/src/content/docs/guides/deployment.mdx
@@ -15,7 +15,7 @@ Astro projects that are entirely pre-rendered do not need any special configurat
 
 ### On-demand rendered
 
-Astro projects that have [enabled on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#enable-on-demand-server-rendering) should take special when using Astro Icon.
+Astro projects that have [enabled on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#enable-on-demand-server-rendering) should take special care when using Astro Icon.
 
 By default, all `@iconify-json/*` packages will be bundled into your server code, potentially bloating your server JavaScript bundles.
 


### PR DESCRIPTION
A very small PR, when reading docs I noticed a missing word:

> ...should take special _ when using Astro Icon

So I added the word 'care':

> ...should take special care when using Astro Icon