### PR TITLE
Revert sizing change

### DIFF
--- a/.changeset/afraid-rivers-agree.md
+++ b/.changeset/afraid-rivers-agree.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fixes a regression in `1.0.3` that changed how icons were sized

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -108,7 +108,7 @@ if (props.size) {
   props.height = props.size;
   delete props.size;
 }
-const renderData = iconToSVG(iconData, { width: "auto", height: "auto" });
+const renderData = iconToSVG(iconData);
 const normalizedProps = { ...renderData.attributes, ...props };
 const normalizedBody = renderData.body;
 ---


### PR DESCRIPTION
Fixes #196

Rolls back the changes introduced in #186. We will need to find a different API for automatically sizing SVGs without forcing everyone into a square aspect ratio.