### PR TITLE
Add support for `is:inline` directive

### DIFF
--- a/.changeset/nine-waves-film.md
+++ b/.changeset/nine-waves-film.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": minor
+---
+
+Adds support for the `is:inline` directive, which bypasses automatic sprite optimization and directly embeds the plain SVG.

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -15,7 +15,6 @@ const icon = "adjustment";
 
   <article>
     <h2>Local Icons</h2>
-    <!-- This will inline your SVG directly -->
     <Icon size={24} name="adjustment" />
     <Icon size={24} name={icon} />
     <Icon size={24} name="annotation" />
@@ -23,6 +22,8 @@ const icon = "adjustment";
     <Icon name="logos/deno" />
     <Icon width={75} name="logos/alpine" />
     <Icon name="logos/alpine-multi-color" />
+
+    <Icon is:inline size={24} name="adjustment" />
   </article>
 
   <article>

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -9,6 +9,7 @@ import { cache } from "./cache.js";
 
 interface Props extends HTMLAttributes<"svg"> {
   name: Icon;
+  "is:inline"?: boolean;
   title?: string;
   size?: number;
   width?: number;
@@ -24,7 +25,7 @@ class AstroIconError extends Error {
 }
 
 const req = Astro.request;
-const { name = "", title, ...props } = Astro.props;
+const { name = "", title, "is:inline": inline = false, ...props } = Astro.props;
 const map = cache.get(req) ?? new Map();
 const i = map.get(name) ?? 0;
 map.set(name, i + 1);
@@ -33,7 +34,7 @@ cache.set(req, map);
 const { include = {} } = config;
 const sets = Object.keys(include);
 
-const includeSymbol = i === 0;
+const includeSymbol = !inline && i === 0;
 
 let [setName, iconName] = (name as string).split(":");
 
@@ -115,6 +116,14 @@ const normalizedBody = renderData.body;
 
 <svg {...normalizedProps} data-icon={name}>
   {title && <title>{title}</title>}
-  {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
-  <use xlink:href={`#${id}`}></use>
+  {
+    inline ? (
+      <Fragment id={id} set:html={normalizedBody} />
+    ) : (
+      <Fragment>
+        {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
+        <use xlink:href={`#${id}`} />
+      </Fragment>
+    )
+  }
 </svg>


### PR DESCRIPTION
Resolves #193, resolves #194

Adds support for a new `is:inline` directive which bypasses the automatic sprite optimization and just inlines the SVG directly. This directive addresses the use cases outlined in #193 and #194.