### PR TITLE
Add support for passthrough attributes

### DIFF
--- a/.changeset/warm-suns-obey.md
+++ b/.changeset/warm-suns-obey.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": minor
+---
+
+Adds support for passthrough attributes like `stroke-width` and `stroke-linejoin`. These attributes will be passed from the `<Icon />` component down to the rendered `svg` element.

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -5,7 +5,7 @@ import icons, { config } from "virtual:astro-icon";
 import type { Icon } from "virtual:astro-icon";
 import { getIconData, iconToSVG } from "@iconify/utils";
 import type { HTMLAttributes } from "astro/types";
-import { cache } from "./cache.js";
+import { cache, applyPassthroughAttributes } from "./utils.js";
 
 interface Props extends HTMLAttributes<"svg"> {
   name: Icon;
@@ -109,9 +109,11 @@ if (props.size) {
   props.height = props.size;
   delete props.size;
 }
+
 const renderData = iconToSVG(iconData);
 const normalizedProps = { ...renderData.attributes, ...props };
-const normalizedBody = renderData.body;
+const normalizedBody = applyPassthroughAttributes(renderData.body, props);
+
 ---
 
 <svg {...normalizedProps} data-icon={name}>
@@ -123,7 +125,7 @@ const normalizedBody = renderData.body;
       <Fragment>
         {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
         <use xlink:href={`#${id}`} />
-      </Fragment>
+   </Fragment>
     )
   }
 </svg>

--- a/packages/core/components/cache.ts
+++ b/packages/core/components/cache.ts
@@ -1,1 +1,0 @@
-export const cache = new WeakMap<Request, Map<string, number>>();

--- a/packages/core/components/utils.ts
+++ b/packages/core/components/utils.ts
@@ -1,0 +1,16 @@
+export const cache = new WeakMap<Request, Map<string, number>>();
+
+// TODO: are there other attributes we should pass through?
+function isPassthroughAttribute(key: string) {
+    if (key.startsWith('stroke-')) return true;
+}
+
+// TODO: not the most robust, but it works
+export function applyPassthroughAttributes(body: string, props: Record<string, any>) {
+    for (const [key, value] of Object.entries(props)) {
+        if (!isPassthroughAttribute(key)) continue;
+        if (!body.includes(`${key}="`)) continue;
+        body = body.replace(new RegExp(`${key}="[^"]"`, 'g'), `${key}="${value}"`)
+    }
+    return body;
+}

--- a/packages/core/components/utils.ts
+++ b/packages/core/components/utils.ts
@@ -2,15 +2,18 @@ export const cache = new WeakMap<Request, Map<string, number>>();
 
 // TODO: are there other attributes we should pass through?
 function isPassthroughAttribute(key: string) {
-    if (key.startsWith('stroke-')) return true;
+  if (key.startsWith("stroke-")) return true;
 }
 
 // TODO: not the most robust, but it works
-export function applyPassthroughAttributes(body: string, props: Record<string, any>) {
-    for (const [key, value] of Object.entries(props)) {
-        if (!isPassthroughAttribute(key)) continue;
-        if (!body.includes(`${key}="`)) continue;
-        body = body.replace(new RegExp(`${key}="[^"]"`, 'g'), `${key}="${value}"`)
-    }
-    return body;
+export function applyPassthroughAttributes(
+  body: string,
+  props: Record<string, any>,
+) {
+  for (const [key, value] of Object.entries(props)) {
+    if (!isPassthroughAttribute(key)) continue;
+    if (!body.includes(`${key}="`)) continue;
+    body = body.replace(new RegExp(`${key}="[^"]"`, "g"), `${key}="${value}"`);
+  }
+  return body;
 }


### PR DESCRIPTION
WIP, but the goal is to allow [presentational](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Presentation) attributes to be applied directly to the rendered icon. The main use case is `stroke-width`, but there might be others that I haven't seen yet!

### Still TODO
- [ ] make sure sprites are handled properly
- [ ] less hacky replacement behavior ([`ultrahtml`](https://npm.im/ultrahtml) for parsing?)
- [ ] Handle `true` / `false` attribute values
- [ ] Handle injecting the value when the attribute does not already exist