### PR TITLE
Types - Added Better Typings for Width, Height + Size

### DIFF
--- a/.changeset/nine-poems-teach.md
+++ b/.changeset/nine-poems-teach.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Added better typings for height, width and size to accept non-number values (i.e. 2 rem)

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<"svg"> {
   name: Icon;
   "is:inline"?: boolean;
   title?: string;
-  size?: number;
-  width?: number;
-  height?: number;
+  size?: number | string;
+  width?: number | string;
+  height?: number | string;
 }
 
 class AstroIconError extends Error {

--- a/packages/www/src/content/docs/guides/components.mdx
+++ b/packages/www/src/content/docs/guides/components.mdx
@@ -31,9 +31,9 @@ interface Props extends HTMLAttributes<"svg"> {
   /** Shorthand for including a <title>{props.title}</title> element in the SVG */
   title?: string;
   /** Shorthand for setting width and height */
-  size?: number;
-  width?: number;
-  height?: number;
+  size?: number | string;
+  width?: number | string;
+  height?: number | string;
 }
 ```
 


### PR DESCRIPTION
Fixes #213

* Made `width`, `height` and `size` able to accept a `string` value as well as a `number` value (i.e. for using `rem`, `px`, etc.)

However, this is similar to the inherent attributes associated with an `<svg>` tag:
![image](https://github.com/natemoo-re/astro-icon/assets/20507092/3f33ab54-c1a2-4493-bf91-e304713a60ad)

So - an alternate solution may be just removing these attributes from the props entirely, and just relying on the `extends HTMLAttributes<"svg">` instead. 