### PR TITLE
feat: add symbol prop to <Icon> for <use> integration in UI frameworks

### DIFF
--- a/.changeset/twenty-pianos-hope.md
+++ b/.changeset/twenty-pianos-hope.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": minor
+---
+
+feat: add `symbol` prop to `<Icon>` for `<use>` integration in UI frameworks

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -15,6 +15,14 @@ const icon = "adjustment";
 
   <article>
     <h2>Local Icons</h2>
+    <!-- SVG sprite -->
+    <svg width="0" height="0">
+      <Icon name="adjustment" symbol />
+      <Icon name="adjustment" symbol />
+      <Icon name="annotation" symbol />
+      <Icon name="logos/deno" symbol />
+    </svg>
+
     <Icon size={24} name="adjustment" />
     <Icon size={24} name={icon} />
     <Icon size={24} name="annotation" />
@@ -33,6 +41,15 @@ const icon = "adjustment";
       render it here!
     </p>
   </article>
+
+  <!-- SVG sprite -->
+  <svg width="0" height="0">
+    <Icon name="ic:baseline-account-box" symbol />
+    <Icon name="ic:baseline-account-box" symbol />
+    <Icon name="annotation" symbol />
+    <Icon name="ri:aliens-fill" symbol />
+  </svg>
+
   <!-- Pull your icon from the default remote service -->
   <Icon size={32} name="ic:baseline-account-box" />
   <Icon size={64} name="ic:baseline-account-box" />

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -14,6 +14,7 @@ interface Props extends HTMLAttributes<"svg"> {
   size?: number | string;
   width?: number | string;
   height?: number | string;
+  symbol?: boolean;
 }
 
 class AstroIconError extends Error {
@@ -25,7 +26,7 @@ class AstroIconError extends Error {
 }
 
 const req = Astro.request;
-const { name = "", title, "is:inline": inline = false, ...props } = Astro.props;
+const { name = "", title, "is:inline": inline = false, symbol: isSymbol, ...props } = Astro.props;
 const map = cache.get(req) ?? new Map();
 const i = map.get(name) ?? 0;
 map.set(name, i + 1);
@@ -112,18 +113,22 @@ if (props.size) {
 const renderData = iconToSVG(iconData);
 const normalizedProps = { ...renderData.attributes, ...props };
 const normalizedBody = renderData.body;
+const symbolProps = isSymbol ? { viewBox: renderData.attributes.viewBox } : {};
 ---
-
-<svg {...normalizedProps} data-icon={name}>
-  {title && <title>{title}</title>}
-  {
-    inline ? (
-      <Fragment id={id} set:html={normalizedBody} />
-    ) : (
-      <Fragment>
-        {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
-        <use xlink:href={`#${id}`} />
-      </Fragment>
-    )
-  }
-</svg>
+{
+  isSymbol && !inline
+    ? (includeSymbol ? <symbol id={id} set:html={normalizedBody} {...symbolProps} /> : <></>)
+    : <svg {...normalizedProps} data-icon={name}>
+      {title && <title>{title}</title>}
+      {
+        inline ? (
+          <Fragment id={id} set:html={normalizedBody} />
+        ) : (
+          <Fragment>
+            {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
+            <use xlink:href={`#${id}`} />
+          </Fragment>
+        )
+      }
+    </svg>
+}

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -113,7 +113,7 @@ if (props.size) {
 const renderData = iconToSVG(iconData);
 const normalizedProps = { ...renderData.attributes, ...props };
 const normalizedBody = renderData.body;
-const symbolProps = isSymbol ? { viewBox: renderData.attributes.viewBox } : {};
+const symbolProps = { viewBox: renderData.attributes.viewBox };
 ---
 {
   isSymbol && !inline
@@ -125,7 +125,7 @@ const symbolProps = isSymbol ? { viewBox: renderData.attributes.viewBox } : {};
           <Fragment id={id} set:html={normalizedBody} />
         ) : (
           <Fragment>
-            {includeSymbol && <symbol id={id} set:html={normalizedBody} />}
+            {includeSymbol && <symbol id={id} set:html={normalizedBody} {...symbolProps} />}
             <use xlink:href={`#${id}`} />
           </Fragment>
         )


### PR DESCRIPTION
## Description:
This PR introduces a new prop symbol to the Icon component, allowing the component to return an SVG `<symbol>` element instead of a full `<svg>` element. The symbol includes the `id` and `viewBox` attributes, making it easier to reference icons using `<use>`, particularly in UI frameworks like Vue, React, or Svelte.

## Motivation:
Previously, the `Icon` component allowed reusing icons, but in UI frameworks such as Vue, React, or Svelte, it required passing the icons through slots, which could be inconvenient. With the introduction of the `symbol` prop, icons can now be referenced via the `<use>` element, enabling a more flexible and efficient way to use icons across the application, without relying on slots.

## Changes:
Added a symbol prop to the Icon component.
When `symbol={true}`, the component will return a `<symbol>` element with the appropriate `id` and `viewBox` attributes instead of rendering a standalone `<svg>` element.
This update allows developers to reference icons using `<use>`, improving flexibility and integration in UI frameworks.

## Example Usage:
```
<!-- Create a sprite-->
<svg width="0" height="0">
    <Icon name="mdi:home" symbol />
    <Icon name="mdi:dog" symbol />
    <Icon name="local-icon" symbol />
</svg>

<!-- Then reference the icon in UI framework using <use> -->
<svg width="24" height="24">
    <use href="#ai:mdi:dog" />
</svg>
```

## Benefits:
Provides a more flexible way to reuse icons in frameworks like Vue, React, or Svelte, without the need to use slots.
Allows referencing icons with `<use>`, making it easier to integrate icons into the DOM structure.
Reduces redundant SVG code by reusing the same symbol definition across multiple instances.

## Testing:
This feature has been tested with various icon sets and confirmed to work smoothly with Astro islands and other UI frameworks. The default behavior (rendering a full SVG) remains unchanged if the symbol prop is not used.

### Related Issue:

https://github.com/natemoo-re/astro-icon/issues/151