### PR TITLE
feat(desc): support desc svg tag.

### DIFF
--- a/.changeset/curvy-lions-dream.md
+++ b/.changeset/curvy-lions-dream.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Adds a `desc` prop shorthand which maps to the SVG `<desc>` tag, similar to `title`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -101,6 +101,7 @@ interface Props extends HTMLAttributes<"svg"> {
   name: string;
   "is:inline"?: boolean;
   title?: string;
+  desc?: string;
   size?: number | string;
   width?: number | string;
   height?: number | string;

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -11,6 +11,7 @@ interface Props extends HTMLAttributes<"svg"> {
   name: Icon;
   "is:inline"?: boolean;
   title?: string;
+  desc?: string;
   size?: number | string;
   width?: number | string;
   height?: number | string;
@@ -25,7 +26,7 @@ class AstroIconError extends Error {
 }
 
 const req = Astro.request;
-const { name = "", title, "is:inline": inline = false, ...props } = Astro.props;
+const { name = "", title, desc, "is:inline": inline = false, ...props } = Astro.props;
 const map = cache.get(req) ?? new Map();
 const i = map.get(name) ?? 0;
 map.set(name, i + 1);
@@ -116,6 +117,7 @@ const normalizedBody = renderData.body;
 
 <svg {...normalizedProps} data-icon={name}>
   {title && <title>{title}</title>}
+  {desc && <desc>{desc}</desc>}
   {
     inline ? (
       <Fragment id={id} set:html={normalizedBody} />

--- a/packages/www/src/content/docs/guides/components.mdx
+++ b/packages/www/src/content/docs/guides/components.mdx
@@ -30,6 +30,8 @@ interface Props extends HTMLAttributes<"svg"> {
   name: string;
   /** Shorthand for including a <title>{props.title}</title> element in the SVG */
   title?: string;
+  /** Shorthand for including a <desc>{props.desc}</desc> element in the SVG */
+  desc?: string;
   /** Shorthand for setting width and height */
   size?: number | string;
   width?: number | string;


### PR DESCRIPTION
# Description

I was using astro-icon for the first time as a part of a [course](https://learnastro.dev/) I'm taking, and I was curious about some accessibility details. Looking into it, I saw that astro-icon supports the `title` tag, but doesn't yet support the `desc` tag. 

`<desc>` isn't used as commonly as `<title>`, but can be an important tag for complex svgs. Read more about it here: [https://www.w3.org/TR/SVG11/struct.html#DescriptionAndTitleElements](https://www.w3.org/TR/SVG11/struct.html#DescriptionAndTitleElements).


# Testing

I used yalc to link my locally-built astro-icon package and was able to pass a `desc` prop to my icon, which was added as a `desc` tag. Let me know if there are other ways to test, or edge cases I should look into.