### PR TITLE
fix: include aliases in icon type definitions and hash calculation

### DIFF
--- a/.changeset/chilled-fans-beg.md
+++ b/.changeset/chilled-fans-beg.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+fix: include aliases in icon type definitions and hash calculation

--- a/.changeset/chilled-fans-beg.md
+++ b/.changeset/chilled-fans-beg.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-fix: include aliases in icon type definitions and hash calculation
+Fixes type definitions and hash calculation for aliased icon names

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -90,14 +90,16 @@ declare module 'virtual:astro-icon' {
       collections.length > 0
         ? collections
             .map((collection) =>
-              Object.keys(collection.icons).map(
-                (icon) =>
-                  `\n\t\t| "${
-                    collection.prefix === defaultPack
-                      ? ""
-                      : `${collection.prefix}:`
-                  }${icon}"`,
-              ),
+              Object.keys(collection.icons)
+                .concat(Object.keys(collection.aliases ?? {}))
+                .map(
+                  (icon) =>
+                    `\n\t\t| "${
+                      collection.prefix === defaultPack
+                        ? ""
+                        : `${collection.prefix}:`
+                    }${icon}"`,
+                ),
             )
             .flat(1)
             .join("")
@@ -111,7 +113,12 @@ function collectionsHash(collections: IconCollection[]): string {
   const hash = createHash("sha256");
   for (const collection of collections) {
     hash.update(collection.prefix);
-    hash.update(Object.keys(collection.icons).sort().join(","));
+    hash.update(
+      Object.keys(collection.icons)
+        .concat(Object.keys(collection.aliases ?? {}))
+        .sort()
+        .join(","),
+    );
   }
   return hash.digest("hex");
 }


### PR DESCRIPTION
Currently, the generated icon type definitions (`.astro/icon.d.ts`) do not include aliases from IconifyJSON.

In my case, I am using Material Design Icons as `<Icon name="mdi:external-link" />` and adding `/// <reference path="../.astro/icon.d.ts" />` to `src/env.d.ts`. However, `astro check` fails due to a type error. This is because "mdi:external-link" is an alias of "mdi:open-in-new" and the alias is not recognized in the type definitions.

This fix updates the icon type generation process to include aliases from IconifyJSON, allowing type checking to recognize both original names and their aliases. Additionally, the hash calculation has been adjusted to account for these aliases.