### PR TITLE
Fix icon reloading logic to only trigger for relevant file changes

### DIFF
--- a/.changeset/twelve-students-remain.md
+++ b/.changeset/twelve-students-remain.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fix icon reloading logic to only trigger for relevant file changes

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -9,6 +9,7 @@ import type {
 import loadLocalCollection from "./loaders/loadLocalCollection.js";
 import loadIconifyCollections from "./loaders/loadIconifyCollections.js";
 import { createHash } from "node:crypto";
+import Path from 'node:path'
 
 interface PluginContext extends Pick<AstroConfig, "root" | "output"> {
   logger: AstroIntegrationLogger;
@@ -49,7 +50,12 @@ export function createPlugin(
     },
     configureServer({ watcher, moduleGraph }) {
       watcher.add(`${iconDir}/**/*.svg`);
-      watcher.on("change", async () => {
+      watcher.on("all", async (_, filepath: string) => {
+        const parsedPath = Path.parse(filepath)
+        const resolvedIconDir = Path.resolve(root.pathname, iconDir)
+        const isSvgFileInIconDir = parsedPath.dir.startsWith(resolvedIconDir) && parsedPath.ext === ".svg";
+        const isAstroConfig = parsedPath.name === "astro.config";
+        if (!isSvgFileInIconDir && !isAstroConfig) return;        
         console.log(`Local icons changed, reloading`);
         try {
           if (!collections) {


### PR DESCRIPTION
# Description:

This PR resolves #257, where unnecessary reloads are triggered when files in unrelated directories are modified (#251). It also fixes the issue where new files added to the `iconDir` directory do not trigger a reload due to the watcher only listening to `change` events.

# Changes:

- Listens to all events to ensure that any file creation, modification, or deletion is captured.
- Ensures that only changes within the `iconDir` (specifically .svg files) or the `astro.config` file triggers the reload event.

# Testing:

## Before:

![image](https://github.com/user-attachments/assets/6f6b15bd-02a0-4cb2-a4bb-cb3af4f3ec60)


https://github.com/user-attachments/assets/dbd27c4a-d69f-40e9-b9f5-2fff84fb4fbe


## After:

![image](https://github.com/user-attachments/assets/2c556b90-b77e-4738-8353-39738acfc599)

https://github.com/user-attachments/assets/afd2aba2-c4a8-4ba7-985d-0d363e3f2bc3


Related PR: #251 