### PR TITLE
FIX: throw error when local `iconDir` fails to load

### DIFF
--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -62,6 +62,7 @@ export function createPlugin(
           moduleGraph.invalidateAll();
         } catch (ex) {
           // Failed to load the local collection
+          throw new Error(`Failed to load local collection at: ${iconDir}`);
         }
         return `export default ${JSON.stringify(collections)};\nexport const config = ${JSON.stringify({ include })}`;
       });


### PR DESCRIPTION
When `iconDir` doesn't exist. Any changes made to files will stop working due to how the code is set to call `moduleGraph.invalidateAll()` only _after_ all icons are loaded.

This change adds an error message that the local collection has failed to load.

Resolves: #260 