### PR TITLE
add compile-time checks for duplicate icons

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,8 @@ import type { IntegrationOptions } from "../typings/integration";
 import { createPlugin } from "./vite-plugin-astro-icon.js";
 import type { AstroIntegration } from "astro";
 
-export default function createIntegration(
-  opts: IntegrationOptions = {},
+export default function createIntegration<T extends Record<string, ["*"] | readonly string[]>>(
+  opts: IntegrationOptions<T> = {},
 ): AstroIntegration {
   return {
     name: "astro-icon",

--- a/packages/core/src/loaders/loadIconifyCollections.ts
+++ b/packages/core/src/loaders/loadIconifyCollections.ts
@@ -22,11 +22,11 @@ export default async function loadIconifyCollections({
   root,
   include = {},
 }: LoadOptions): Promise<AstroIconCollectionMap> {
+  const includeMutable: Record<string, ["*"] | string[]> = { ...include };
   const installedCollections = await detectInstalledCollections(root);
-  // If icons are installed locally but not explicitly included, include the whole pack
   for (let name of installedCollections) {
-    if (include[name] !== undefined) continue;
-    include[name] = ["*"];
+    if (includeMutable[name] !== undefined) continue;
+    includeMutable[name] = ["*"];
   }
   const possibleCollections = await Promise.all(
     installedCollections.map((collectionName) =>
@@ -45,7 +45,7 @@ export default async function loadIconifyCollections({
         return acc;
       }
 
-      const requestedIcons = Array.from(new Set(include[name]));
+      const requestedIcons = Array.from(new Set(includeMutable[name]));
 
       // Requested entire icon collection
       if (requestedIcons.length === 1 && requestedIcons[0] === "*") {

--- a/packages/core/typings/integration.d.ts
+++ b/packages/core/typings/integration.d.ts
@@ -1,7 +1,37 @@
 import type { IconifyJSON, SVGOOptions } from "./iconify";
 
-export type IntegrationOptions = {
-  include?: Record<string, ["*"] | string[]>;
+type IsUnique<T extends readonly string[]> =
+  T extends readonly [infer First, ...infer Rest]
+    ? First extends Rest[string]
+      ? false
+      : IsUnique<Rest>
+    : true;
+
+type ExtractDuplicates<T extends readonly string[]> =
+  T extends readonly [infer First, ...infer Rest]
+    ? First extends Rest[string]
+      ? First | ExtractDuplicates<Rest>
+      : ExtractDuplicates<Rest>
+    : never;
+
+type UniqueArrayError<T extends string> = [
+  `Error: Duplicate value "${T}" found in array. Use unique values.`,
+  ...T[]
+];
+
+type ValidateInclude<T extends Record<string, ["*"] | readonly string[]>> = {
+  [K in keyof T]:
+    T[K] extends ["*"]
+      ? T[K]
+      : T[K] extends readonly string[]
+        ? IsUnique<T[K]> extends true
+          ? T[K]
+          : UniqueArrayError<ExtractDuplicates<T[K]>>
+        : never;
+};
+
+export type IntegrationOptions<T extends Record<string, ["*"] | readonly string[]> = {}> = {
+  include?: ValidateInclude<T>;
   /**
    * @default "src/icons"
    */


### PR DESCRIPTION
Hi @natemoo-re ,

I found that we have duplicate icon name occurrences in our include files, and such duplicates can cause unpredictable behavior. To correct that, I added build-time checking for duplicates to make our icon management system more reliable.