### PR TITLE
chore: Update @iconify/tools and @iconify/utils versions

### DIFF
--- a/.changeset/update-iconify-deps.md
+++ b/.changeset/update-iconify-deps.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fixes a crash when using the Cloudflare adapter in Astro v6

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,9 +47,9 @@
   },
   "homepage": "https://github.com/natemoo-re/astro-icon#readme",
   "dependencies": {
-    "@iconify/tools": "^4.0.5",
+    "@iconify/tools": "^5.0.5",
     "@iconify/types": "^2.0.0",
-    "@iconify/utils": "^2.1.30"
+    "@iconify/utils": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.18.0",


### PR DESCRIPTION
`@iconify/utils@2.x` and `@iconify/tools@4.x` depend on `debug` (CJS), which breaks the Astro v6 Cloudflare adapter. Debug was removed in v3 and v5 with no changes to the APIs astro-icon uses.

Closes https://github.com/natemoo-re/astro-icon/issues/277