### PR TITLE
fix: keep local icon collections deterministic

### DIFF
--- a/.changeset/calm-icons-build.md
+++ b/.changeset/calm-icons-build.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Keep generated local icon collections deterministic across unchanged builds.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "pnpm run dev"
+    "start": "pnpm run dev",
+    "test": "pnpm run build && node --test test/*.test.mjs"
   },
   "author": {
     "name": "Nate Moore",

--- a/packages/core/src/loaders/loadLocalCollection.ts
+++ b/packages/core/src/loaders/loadLocalCollection.ts
@@ -59,7 +59,9 @@ export default async function createLocalCollection(
     local.fromSVG(name, svg);
   });
 
-  return local.export(true);
+  const collection = local.export(true);
+  delete collection.lastModified;
+  return collection;
 }
 
 async function convertToCurrentColor(svg: SVG): Promise<void> {

--- a/packages/core/test/loadLocalCollection.test.mjs
+++ b/packages/core/test/loadLocalCollection.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import loadLocalCollection from "../dist/loaders/loadLocalCollection.js";
+
+test("local collections are deterministic", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "astro-icon-"));
+  try {
+    await writeFile(
+      join(directory, "example.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>',
+    );
+
+    const first = await loadLocalCollection(directory);
+    const second = await loadLocalCollection(directory);
+
+    assert.deepEqual(first, second);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
This is from a patch made in https://github.com/cloudflare/cloudflare-docs/pull/32438/changes#diff-3fb62f4af38f5558c8906fac6ac400bdb641dce6a7264ae3b0de0c7e1eb08cbf

What I learned is that this `lastModified` causes https://docs.astro.build/en/reference/experimental-flags/incremental-build/ to _never_ be able to restore cached versions because `astro-icon` (being a dependency) gets a branch new hash each time due to the shape of the object every build.

This removes it naïvely to resolve the issue.

However, **I don't know if there are consequences to this**. As such, I recommend a major version bump to be safe.
