### PR TITLE
fix: avoid Astro.request warning on prerendered pages

### DIFF
--- a/.changeset/violet-lions-explode.md
+++ b/.changeset/violet-lions-explode.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fixes `Astro.request.headers` warning on prerendered pages by keying the internal per-render icon cache off `Astro.locals` instead of `Astro.request`

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -26,12 +26,12 @@ class AstroIconError extends Error {
   }
 }
 
-const req = Astro.request;
+const localsKey = Astro.locals;
 const { name = "", title, desc, "is:inline": inline = false, ...props } = Astro.props;
-const map = cache.get(req) ?? new Map();
+const map = cache.get(localsKey) ?? new Map();
 const i = map.get(name) ?? 0;
 map.set(name, i + 1);
-cache.set(req, map);
+cache.set(localsKey, map);
 
 const { include = {} } = config;
 const sets = Object.keys(include);

--- a/packages/core/components/cache.ts
+++ b/packages/core/components/cache.ts
@@ -1,1 +1,1 @@
-export const cache = new WeakMap<Request, Map<string, number>>();
+export const cache = new WeakMap<object, Map<string, number>>();


### PR DESCRIPTION
## Summary
- `Icon.astro` used `Astro.request` purely as a `WeakMap` key for a per-render cache that dedupes repeated `<symbol>`/`<use>` for the same icon on a page — no header/request data was ever actually read
- Touching `Astro.request` on prerendered routes triggers Astro's build-time warning that `Astro.request.headers` is unavailable there
- Swapped the cache key to `Astro.locals`, which is equally unique per render but always safe to access regardless of prerendering

Fixes #272

## Test plan
- [x] `pnpm --filter astro-icon build` passes
- [x] `demo` app (all pages prerendered) builds with no warnings
- [x] Confirmed icon symbol/dedup behavior is unchanged (`<symbol>` emitted once per icon, correct `<use>` count for repeats)
- [x] Verified clean build with no warnings against Astro 4 (current), 6, and 7