### PR TITLE
fix: strip viewBox from svg wrapper on every icon instance

### DIFF
--- a/.changeset/tame-donuts-shout.md
+++ b/.changeset/tame-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -116,7 +116,7 @@ const normalizedProps = { ...renderData.attributes as Partial<IconifyIconBuildRe
 const normalizedBody = renderData.body;
 
 const { viewBox } = normalizedProps;
-if (includeSymbol) {
+if (!inline) {
   delete normalizedProps.viewBox;
 }
 ---


### PR DESCRIPTION
## Summary
- `viewBox` removal from the `<svg>` wrapper was gated on `includeSymbol`, which is only `true` for the first occurrence of a given icon name on a page (the one that emits the `<symbol>`)
- Repeated instances of the same icon (2nd+) kept a stale `viewBox` on their `<svg>` wrapper, even though the actual geometry now lives on the shared `<symbol>` — inconsistent output for identical markup
- Decoupled `viewBox` stripping from `includeSymbol`: for non-inline rendering, `viewBox` is now stripped from the `<svg>` wrapper consistently regardless of occurrence index

Fixes #249

## Test plan
- [x] `pnpm --filter astro-icon build` passes
- [x] Rendered the same icon twice non-inline in the demo app — both `<svg>` wrappers now consistently omit `viewBox` (previously only the first did)
- [x] `is:inline` usage unaffected, still keeps its own `viewBox`
- [x] Confirmed only one `<symbol viewBox="...">` is emitted per icon, shared by all `<use>` references