### PR TITLE
fix: watch resolved icon dir instead of a broken glob

### DIFF
--- a/.changeset/spicy-plums-hunt.md
+++ b/.changeset/spicy-plums-hunt.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Fix icon dir watcher so newly added local icons (including files inside subfolders) are picked up without restarting the dev server

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -49,15 +49,6 @@ export function createPlugin(
       }
     },
     configureServer({ watcher, moduleGraph }) {
-      // Vite's dev server watcher is created with `disableGlobbing: true`,
-      // so a glob string like `${iconDir}/**/*.svg` is treated as a literal
-      // (non-existent) path rather than a glob pattern. Chokidar's internal
-      // fallback logic for that missing path ends up re-adding `iconDir`
-      // with a broken, non-recursive filter, which silently stops emitting
-      // `add`/`change`/`unlink` events for the whole directory (including
-      // existing and new subfolders) until the dev server is restarted.
-      // Watching the resolved directory itself avoids that failure mode and
-      // ensures `iconDir` is watched even when it lives outside `root`.
       watcher.add(resolve(root.pathname, iconDir));
       watcher.on("all", async (_, filepath: string) => {
         const parsedPath = parse(filepath);

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -49,7 +49,16 @@ export function createPlugin(
       }
     },
     configureServer({ watcher, moduleGraph }) {
-      watcher.add(`${iconDir}/**/*.svg`);
+      // Vite's dev server watcher is created with `disableGlobbing: true`,
+      // so a glob string like `${iconDir}/**/*.svg` is treated as a literal
+      // (non-existent) path rather than a glob pattern. Chokidar's internal
+      // fallback logic for that missing path ends up re-adding `iconDir`
+      // with a broken, non-recursive filter, which silently stops emitting
+      // `add`/`change`/`unlink` events for the whole directory (including
+      // existing and new subfolders) until the dev server is restarted.
+      // Watching the resolved directory itself avoids that failure mode and
+      // ensures `iconDir` is watched even when it lives outside `root`.
+      watcher.add(resolve(root.pathname, iconDir));
       watcher.on("all", async (_, filepath: string) => {
         const parsedPath = parse(filepath);
         const resolvedIconDir = resolve(root.pathname, iconDir);


### PR DESCRIPTION
## Summary
- The dev-server watcher called `watcher.add(`${iconDir}/**/*.svg`)`, but Vite's chokidar instance runs with `disableGlobbing: true`, so that glob string was treated as a literal, non-existent path
- Chokidar's internal fallback for a missing `add()` target re-added `iconDir` with a broken, non-recursive filter, which silently killed watch events (`add`/`change`/`unlink`) for the *entire* icon directory — not just subfolders — for the rest of the dev-server session
- This matches the reported symptom exactly: new/changed icons (top-level or nested) are invisible until the dev server is restarted
- Fix: watch the resolved directory path directly instead of a glob string, since chokidar globbing is disabled anyway

Fixes #204

## Test plan
- [x] Reproduced live against a running `astro dev` server: with the bug present, adding a new SVG under `src/icons` (including subfolders) produced zero watcher events and the icon stayed unresolved indefinitely
- [x] Applied the fix on the same running server (no restart) — `Local icons changed, reloading` fired automatically after adding the new file, and the icon resolved on the next request
- [x] `pnpm --filter astro-icon build` passes