### PR TITLE
fix: warn instead of silently swallowing local collection load errors

### DIFF
--- a/.changeset/short-mice-relax.md
+++ b/.changeset/short-mice-relax.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Log a warning instead of silently swallowing errors when the local icon collection fails to load, so failures during dev/build are visible instead of hidden.

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -43,7 +43,9 @@ export function createPlugin(
           logCollections(collections, { ...ctx, iconDir });
           await generateIconTypeDefinitions(Object.values(collections), root);
         } catch (ex) {
-          // Failed to load the local collection
+          ctx.logger.warn(
+            `Failed to load icons from "${iconDir}": ${ex instanceof Error ? ex.message : ex}`,
+          );
         }
         return `export default ${JSON.stringify(collections)};\nexport const config = ${JSON.stringify({ include })}`;
       }
@@ -69,7 +71,9 @@ export function createPlugin(
           await generateIconTypeDefinitions(Object.values(collections), root);
           moduleGraph.invalidateAll();
         } catch (ex) {
-          // Failed to load the local collection
+          ctx.logger.warn(
+            `Failed to load icons from "${iconDir}": ${ex instanceof Error ? ex.message : ex}`,
+          );
         }
         return `export default ${JSON.stringify(collections)};\nexport const config = ${JSON.stringify({ include })}`;
       });


### PR DESCRIPTION
## Summary
- Both load paths in the Vite plugin (`load` and the `configureServer` watcher handler) caught any failure while loading the local icon collection and discarded it with no logging at all
- This made real failures (bad SVG, misconfigured `iconDir`, etc.) invisible — you'd just see "No icons detected" or a missing-icon error downstream with no clue why
- Now logs a warning with the underlying error message via `ctx.logger.warn`

Related to #260 — the actual live-reload breakage reported there was already fixed by #287 (which replaced a broken `watcher.add()` glob string with a resolved path); this is a small follow-up so any remaining local-collection load failures are visible instead of silent.

## Test plan
- [x] `pnpm --filter astro-icon build` passes
- [x] `pnpm --filter demo build` passes with no behavior change for the normal case