### PR TITLE
fix: strip lastModified from local icon collection for deterministic output

### DIFF
--- a/.changeset/deterministic-local-icons.md
+++ b/.changeset/deterministic-local-icons.md
@@ -1,0 +1,5 @@
+---
+"astro-icon": patch
+---
+
+Strip the `lastModified` timestamp from the generated local icon collection so its output is deterministic across builds, allowing Astro's incremental build cache to work as expected.

--- a/packages/core/src/loaders/loadLocalCollection.ts
+++ b/packages/core/src/loaders/loadLocalCollection.ts
@@ -59,7 +59,9 @@ export default async function createLocalCollection(
     local.fromSVG(name, svg);
   });
 
-  return local.export(true);
+  const collection = local.export(true);
+  delete collection.lastModified;
+  return collection;
 }
 
 async function convertToCurrentColor(svg: SVG): Promise<void> {


### PR DESCRIPTION
## Summary
- The local icon collection generated from `iconDir` gets a fresh `lastModified` timestamp on every build (stamped by `@iconify/tools`' `IconSet` on every `fromSVG` call), even when the source SVGs haven't changed.
- This makes the `virtual:astro-icon` module content non-deterministic across builds, which prevents Astro's [incremental build cache](https://docs.astro.build/en/reference/experimental-flags/incremental-build/) from ever getting a cache hit for astro-icon's local collection.
- `lastModified` isn't read anywhere in astro-icon's own code, so dropping it from the exported collection has no functional impact — it only removes an unused, volatile field from the serialized output.
- Cherry-picked from #280 (dropping the test file addition), credit to @ericclemmons for the diagnosis and fix.

## Test plan
- [x] `pnpm run build` (tsc) passes
- [x] Manually verified two successive calls to `loadLocalCollection` against the same directory now produce byte-identical output (including after a >1s delay, to rule out timestamp-second rounding luck), and that `lastModified` is absent from the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)