### PR TITLE
fix: bump CI/release Node version to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
       - run: pnpm install
 
@@ -55,7 +55,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm -r build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
         env:


### PR DESCRIPTION
## Summary
- The Smoke Test job (and Release job) currently run on Node 18, which was already at EOL.
- `@iconify/tools` was bumped to v5 in #290, which pulled in `@iconify/utils@3.1.4`. Its `lib/loader/warn.js` imports `styleText` from `node:util` at module load time — an API that doesn't exist on Node 18 at all, so any SSR module that transitively imports `@iconify/utils/lib/loader/fs` (i.e. `loadIconifyCollections.js`, `vite-plugin-astro-icon.js`) throws a `SyntaxError` and fails the build.
- This has been breaking `main`'s CI since #290 merged, independent of any package-level fix (pinning `@iconify/utils` wouldn't help long-term either, since Node 18 is EOL).
- Bumps `node-version` to 20 in `ci.yml` (lint + smoke jobs) and `release.yml`.

## Test plan
- [x] CI on this PR should now pass the Smoke Test job that's currently failing on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)