### PR TITLE
fix: keep viewBox on the svg wrapper instead of stripping it

### DIFF
--- a/.changeset/tame-donuts-shout.md
+++ b/.changeset/tame-donuts-shout.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work. The `<use>` element is anchored to the icon's own `viewBox` rect, which keeps icons with a non-zero `min-x`/`min-y` positioned correctly and stops a per-instance `viewBox` override from leaking onto other instances of the same icon.
+Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work. Icons whose `viewBox` has a non-zero `min-x`/`min-y` anchor their `<use>` element so they stay positioned correctly, and a per-instance `viewBox` override no longer leaks onto other instances of the same icon.

--- a/.changeset/tame-donuts-shout.md
+++ b/.changeset/tame-donuts-shout.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon
+Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work.

--- a/.changeset/tame-donuts-shout.md
+++ b/.changeset/tame-donuts-shout.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work.
+Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work. The `<use>` element is anchored to the icon's own `viewBox` rect, which keeps icons with a non-zero `min-x`/`min-y` positioned correctly and stops a per-instance `viewBox` override from leaking onto other instances of the same icon.

--- a/.changeset/tame-donuts-shout.md
+++ b/.changeset/tame-donuts-shout.md
@@ -2,4 +2,4 @@
 "astro-icon": patch
 ---
 
-Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work. Icons whose `viewBox` has a non-zero `min-x`/`min-y` anchor their `<use>` element so they stay positioned correctly, and a per-instance `viewBox` override no longer leaks onto other instances of the same icon.
+Fix `viewBox` being inconsistently present on `<svg>` elements across repeated uses of the same icon. The `viewBox` is now always kept on the `<svg>` element, so attributes that depend on it (such as `preserveAspectRatio`) continue to work. Icons whose `viewBox` has a non-zero `min-x`/`min-y` keep a `viewBox` on their shared `<symbol>` and anchor their `<use>` element, so they stay positioned correctly and a per-instance `viewBox` override no longer leaks onto other instances of the same icon.

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -128,13 +128,26 @@ if (props.size) {
   delete props.size;
 }
 const renderData = iconToSVG(iconData);
-const normalizedProps = {
-  ...(renderData.attributes as Partial<IconifyIconBuildResult["attributes"]>),
-  ...props,
-};
+const attributes = renderData.attributes as Partial<
+  IconifyIconBuildResult["attributes"]
+>;
+const normalizedProps = { ...attributes, ...props };
 const normalizedBody = replaceIDs(renderData.body);
 
-const { viewBox } = normalizedProps;
+// A single <symbol> is shared by every instance of the icon, so it describes the
+// icon's own coordinate space rather than `normalizedProps.viewBox`, which would
+// leak a per-instance override onto every other instance of the same icon.
+const viewBox = attributes.viewBox;
+const [minX, minY, vbWidth, vbHeight] =
+  viewBox?.split(/[\s,]+/).map(Number) ?? [];
+// A <use> without x/y/width/height generates its viewport at user-space (0,0) sized
+// to 100% of the wrapper's viewport, which shifts and clips icons whose viewBox has a
+// non-zero min-x/min-y (https://github.com/natemoo-re/astro-icon/issues/212).
+// Pinning it to the symbol's viewBox rect makes the reference an identity placement,
+// which leaves the wrapper's `viewBox` free to scale and window the icon.
+const useRect = [minX, minY, vbWidth, vbHeight].every(Number.isFinite)
+  ? { x: minX, y: minY, width: vbWidth, height: vbHeight }
+  : {};
 ---
 
 <svg {...normalizedProps} data-icon={name}>
@@ -152,7 +165,7 @@ const { viewBox } = normalizedProps;
         {includeSymbol && (
           <symbol id={id} viewBox={viewBox} set:html={normalizedBody} />
         )}
-        <use href={`#${id}`} />
+        <use href={`#${id}`} {...useRect} />
       </Fragment>
     )
   }

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -140,12 +140,15 @@ const normalizedBody = replaceIDs(renderData.body);
 const viewBox = attributes.viewBox;
 const [minX, minY, vbWidth, vbHeight] =
   viewBox?.split(/[\s,]+/).map(Number) ?? [];
-// A <use> without x/y/width/height generates its viewport at user-space (0,0) sized
-// to 100% of the wrapper's viewport, which shifts and clips icons whose viewBox has a
-// non-zero min-x/min-y (https://github.com/natemoo-re/astro-icon/issues/212).
-// Pinning it to the symbol's viewBox rect makes the reference an identity placement,
-// which leaves the wrapper's `viewBox` free to scale and window the icon.
-const useRect = [minX, minY, vbWidth, vbHeight].every(Number.isFinite)
+// A <use> generates its viewport at user-space (0,0) sized to 100% of the wrapper's
+// viewport, which is already the symbol's viewBox rect for the usual `0 0 W H` icon.
+// An icon whose viewBox has a non-zero min-x/min-y has to say so explicitly, or its
+// artwork renders offset by that origin and clipped
+// (https://github.com/natemoo-re/astro-icon/issues/212).
+const hasOffsetOrigin =
+  [minX, minY, vbWidth, vbHeight].every(Number.isFinite) &&
+  (minX !== 0 || minY !== 0);
+const useRect = hasOffsetOrigin
   ? { x: minX, y: minY, width: vbWidth, height: vbHeight }
   : {};
 ---

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -135,9 +135,6 @@ const normalizedProps = {
 const normalizedBody = replaceIDs(renderData.body);
 
 const { viewBox } = normalizedProps;
-if (!inline) {
-  delete normalizedProps.viewBox;
-}
 ---
 
 <svg {...normalizedProps} data-icon={name}>

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -136,18 +136,7 @@ const normalizedBody = replaceIDs(renderData.body);
 
 const [minX, minY, vbWidth, vbHeight] =
   attributes.viewBox?.split(/[\s,]+/).map(Number) ?? [];
-// The wrapper's `viewBox` scales the icon, so a `0 0 W H` icon needs nothing further:
-// the viewport a bare <use> generates already covers the whole wrapper, and the artwork
-// lands on it 1:1.
-//
-// An icon whose viewBox has a non-zero min-x/min-y does need more, or its artwork
-// renders offset by that origin and clipped
-// (https://github.com/natemoo-re/astro-icon/issues/212). Positioning <use> cannot fix
-// that on its own, because `x`/`y` translate the referenced content along with the
-// viewport. Giving the <symbol> a viewBox is what decouples where the viewport sits
-// from the coordinates the artwork is drawn in, which makes the pair an identity
-// placement. Sourcing it from the icon data rather than `normalizedProps` also keeps a
-// per-instance `viewBox` override off the <symbol>, which every instance shares.
+// Without this the artwork renders offset by its origin and clipped (https://github.com/natemoo-re/astro-icon/issues/212).
 const hasOffsetOrigin =
   [minX, minY, vbWidth, vbHeight].every(Number.isFinite) &&
   (minX !== 0 || minY !== 0);

--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -134,20 +134,24 @@ const attributes = renderData.attributes as Partial<
 const normalizedProps = { ...attributes, ...props };
 const normalizedBody = replaceIDs(renderData.body);
 
-// A single <symbol> is shared by every instance of the icon, so it describes the
-// icon's own coordinate space rather than `normalizedProps.viewBox`, which would
-// leak a per-instance override onto every other instance of the same icon.
-const viewBox = attributes.viewBox;
 const [minX, minY, vbWidth, vbHeight] =
-  viewBox?.split(/[\s,]+/).map(Number) ?? [];
-// A <use> generates its viewport at user-space (0,0) sized to 100% of the wrapper's
-// viewport, which is already the symbol's viewBox rect for the usual `0 0 W H` icon.
-// An icon whose viewBox has a non-zero min-x/min-y has to say so explicitly, or its
-// artwork renders offset by that origin and clipped
-// (https://github.com/natemoo-re/astro-icon/issues/212).
+  attributes.viewBox?.split(/[\s,]+/).map(Number) ?? [];
+// The wrapper's `viewBox` scales the icon, so a `0 0 W H` icon needs nothing further:
+// the viewport a bare <use> generates already covers the whole wrapper, and the artwork
+// lands on it 1:1.
+//
+// An icon whose viewBox has a non-zero min-x/min-y does need more, or its artwork
+// renders offset by that origin and clipped
+// (https://github.com/natemoo-re/astro-icon/issues/212). Positioning <use> cannot fix
+// that on its own, because `x`/`y` translate the referenced content along with the
+// viewport. Giving the <symbol> a viewBox is what decouples where the viewport sits
+// from the coordinates the artwork is drawn in, which makes the pair an identity
+// placement. Sourcing it from the icon data rather than `normalizedProps` also keeps a
+// per-instance `viewBox` override off the <symbol>, which every instance shares.
 const hasOffsetOrigin =
   [minX, minY, vbWidth, vbHeight].every(Number.isFinite) &&
   (minX !== 0 || minY !== 0);
+const symbolViewBox = hasOffsetOrigin ? attributes.viewBox : undefined;
 const useRect = hasOffsetOrigin
   ? { x: minX, y: minY, width: vbWidth, height: vbHeight }
   : {};
@@ -166,7 +170,7 @@ const useRect = hasOffsetOrigin
     ) : (
       <Fragment>
         {includeSymbol && (
-          <symbol id={id} viewBox={viewBox} set:html={normalizedBody} />
+          <symbol id={id} viewBox={symbolViewBox} set:html={normalizedBody} />
         )}
         <use href={`#${id}`} {...useRect} />
       </Fragment>


### PR DESCRIPTION
## Summary

An SVG needs a `viewBox` somewhere to scale artwork into a box. In our non-inline output two elements could hold it: the wrapper `<svg>` or the `<symbol>`. #246 moved it to the `<symbol>` to fix clipped icons (#212), and that is what broke `preserveAspectRatio`, which only works on an element that has a `viewBox` and which users style on the wrapper. #286 made the removal consistent across instances (#249), locking the breakage in for every instance rather than just the first.

This puts the `viewBox` back on the wrapper, as @delucis [asked for in review](https://github.com/natemoo-re/astro-icon/pull/286#issuecomment-3183640707), without regressing #212.

Neither #286 nor this change has shipped yet, so the changeset from #286 is amended rather than adding a new one.

## Standard icons: one `viewBox`, same place `is:inline` puts it

```html
<svg width="24" height="24" viewBox="0 0 24 24" data-icon="adjustment">
  <symbol id="ai:local:adjustment">…</symbol>
  <use href="#ai:local:adjustment" />
</svg>
```

The wrapper's `viewBox` does all the scaling. A bare `<use>` already generates a viewport covering the whole wrapper, so the artwork lands on it 1:1 and the `<symbol>` needs nothing. Non-inline output is now the inline output plus a `<use>` indirection.

## Offset-origin icons: the one case that needs more

An icon whose `viewBox` has a non-zero `min-x`/`min-y` (SVG-Crop output, for example `viewBox="4.93 2 22.15 28"`) has artwork that does not start at `(0, 0)`, so the default `<use>` viewport puts it in the wrong place and it clips. That is #212, and it is why #246 stripped the wrapper's `viewBox` in the first place.

Positioning `<use>` cannot fix this alone, because `x`/`y` translate the referenced content along with the viewport, so the two never come into alignment. A `viewBox` on the `<symbol>` is what decouples where the viewport sits from the coordinates the artwork is drawn in. These icons keep both, which makes the reference an identity placement and leaves the wrapper's `viewBox` free to do its job:

```html
<svg width="100" height="100" viewBox="4.93 2 22.15 28" data-icon="cropped">
  <symbol id="ai:local:cropped" viewBox="4.93 2 22.15 28">…</symbol>
  <use href="#ai:local:cropped" x="4.93" y="2" width="22.15" height="28" />
</svg>
```

## Also fixed

The `<symbol>`'s `viewBox` is sourced from the icon data rather than the merged props. A `<symbol>` is emitted once and shared by every instance, so `<Icon name="foo" viewBox="0 0 12 12" />` was stamping that override onto the shared symbol and mis-scaling every *other* `<Icon name="foo" />` on the page.

## Test plan
- [x] `pnpm --filter astro-icon build`
- [x] Built the demo app: every `<svg data-icon>` carries a `viewBox`, no `<symbol>` or `<use>` carries an extra attribute
- [x] Added a local icon with `viewBox="4.93 2 22.15 28"`: both instances emit an identical anchored `<use>` and a `<symbol viewBox>`
- [x] Repeated instances of one icon emit identical markup, and `is:inline` is untouched

Rendering was verified by inspecting the built markup and reasoning against the SVG spec, not by rasterizing in a browser. A visual check against the #212 reproduction before merging would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
