### PR TITLE
fix: bump GitHub Actions to Node 24-based majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -35,7 +35,7 @@ jobs:
       # Otherwise, run lint autofixer
       - name: Lint
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
-        uses: wearerequired/lint-action@v1.10.0
+        uses: wearerequired/lint-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -51,9 +51,9 @@ jobs:
     name: Smoke Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     name: Changelog PR or Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- CI was emitting deprecation warnings on both the Lint and Smoke Test jobs: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4, wearerequired/lint-action@v1.10.0."
- These actions declare a `node20` runtime in their `action.yml`, which GitHub now force-upgrades to Node 24 with a warning. Bumping to their latest majors removes the warning since they declare `node24` natively.
- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `pnpm/action-setup` v4 → v6 (still supports pnpm v10 and older; version is picked up automatically from the repo's `packageManager` field, so no other config changes needed)
- `wearerequired/lint-action` v1.10.0 → v3 (no breaking changes to the `prettier`/`auto_fix` inputs we use; also includes an unrelated command-injection fix)

## Test plan
- [ ] CI lint + smoke test jobs pass with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)