### PR TITLE
chore: migrate changesets/action to v2, prep for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - 'main'
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 defaults:
   run:
     shell: bash
@@ -21,19 +26,15 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm install
+      - run: npm install -g npm@latest
       - run: pnpm --filter astro-icon run build
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          version: pnpm run version
-          publish: pnpm changeset publish
-          commit: 'chore: release'
-          title: 'chore: release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          version-script: pnpm run version
+          publish-script: pnpm changeset publish
+          commit-message: 'chore: release'
+          pr-title: 'chore: release'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump `changesets/action` from `@v1` to `@v2`, updating renamed inputs (`version`→`version-script`, `publish`→`publish-script`, `commit`→`commit-message`, `title`→`pr-title`) and passing `github-token` as an input instead of the now-unsupported `GITHUB_TOKEN` env var.
- Drop `NPM_TOKEN`/`NODE_AUTH_TOKEN` wiring — v2 removed automatic `.npmrc` handling for `NPM_TOKEN` in favor of npm's OIDC-based Trusted Publishing.
- Add `id-token: write` (required for the OIDC token exchange) plus `contents: write` / `pull-requests: write` (required since v2 no longer falls back to `actions/checkout` credentials for pushing the release commit/PR).
- Add an `npm install -g npm@latest` step so the runner's npm is new enough (>=11.5.1) to perform Trusted Publishing.

This assumes a Trusted Publisher has been (or will be) configured for the `astro-icon` package on npmjs.com, pointing at this repo/workflow — without that, publish will fail since there's no token-based auth left.

## Test plan
- [ ] Confirm the `astro-icon` npm package has a Trusted Publisher configured for `natemoo-re/astro-icon` / `release.yml`
- [ ] Merge this PR and watch the next `chore: release` PR + publish run in the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)